### PR TITLE
Add ability to change uid and gid of process

### DIFF
--- a/src/process.cr
+++ b/src/process.cr
@@ -18,13 +18,21 @@ require "./system/group"
 class Process
   # Sets the real, effective, and saved `User` to the one specified.
   def self.user=(user : System::User) : Nil
-    return if LibC.setuid(user.uid) == 0
+    self.uid = user.uid
+  end
+
+  def self.uid=(uid : UInt32) : Nil
+    return if LibC.setuid(uid) == 0
     raise Errno.new("The calling process was not privileged")
   end
 
   # Sets the real, effective, and saved `Group` to the one specified.
   def self.group=(group : System::Group) : Nil
-    return if LibC.setgid(group.gid) == 0
+    self.gid = group.gid
+  end
+  
+  def self.gid=(gid : UInt32) : Nil
+    return if LibC.setgid(gid) == 0
     raise Errno.new("The calling process was not privileged")
   end
 
@@ -32,6 +40,11 @@ class Process
   def self.become(user : System::User, group : System::Group) : Nil
     self.group = group
     self.user = user
+  end
+
+  def self.become(uid : UInt32, gid : UInt32) : Nil
+    self.gid = gid
+    self.uid = uid
   end
 
   # Returns a `Bool` indicating if the current process is running as root.


### PR DESCRIPTION
This adds methods for changing the uid and gid of a process with only the uid and gid:
```
Process.uid=(uid : UInt32)
Process.gid=(gid : UInt32)
Process.become(uid : UInt32, gid : UInt32)
```

Those methods are especially useful in docker environments where you may have to change the uid and gid of the process but the user does not exist in the container. 